### PR TITLE
Hex improvements

### DIFF
--- a/dreal/smt2/scanner.ll
+++ b/dreal/smt2/scanner.ll
@@ -60,6 +60,7 @@ typedef dreal::Smt2Parser::token_type token_type;
 whitespace      [\x09 \xA0]
 printable_char  [\x20-\x7E\xA0-xFF]
 digit           [0-9]
+hex             [0-9a-fA-F]
 letter          [a-zA-Z]
 numeral         0|[1-9][0-9]*
 decimal         {numeral}\.0*{numeral}
@@ -188,7 +189,7 @@ simple_symbol   {sym_begin}{sym_continue}*
     return token::DOUBLE;
 }
 
-"-"?"0"("x"|"X")[0-9]\.[0-9a-fA-F]+"p"("+"|"-")?[0-9]+  {
+[-+]?0[xX]({hex}+\.?|{hex}*\.{hex}+)([pP][-+]?[0-9]+)? {
     yylval->doubleVal = atof(yytext);
     return token::DOUBLE;
 }

--- a/dreal/test/smt2/BUILD
+++ b/dreal/test/smt2/BUILD
@@ -282,6 +282,11 @@ smt2_test(
 )
 
 smt2_test(
+    name = "hex_02",
+    size = "small",
+)
+
+smt2_test(
     name = "int_01",
     size = "small",
 )

--- a/dreal/test/smt2/hex_02.smt2
+++ b/dreal/test/smt2/hex_02.smt2
@@ -1,0 +1,12 @@
+(set-logic QF_NRA)
+
+(assert (= 0xAB.CDp+12 703696.0))
+
+(assert (= 0x0.A 0.625))     ;; exponent omitted
+(assert (= 0xBp+2 44))       ;; point omitted
+(assert (= 0xA. 10))         ;; fractional part omitted
+(assert (= 0x.A 0.625))      ;; integer part omitted
+(assert (= +0x0.Ap+0 0.625)) ;; plus sign prefix
+
+(check-sat)
+(exit)

--- a/dreal/test/smt2/hex_02.smt2.expected
+++ b/dreal/test/smt2/hex_02.smt2.expected
@@ -1,0 +1,1 @@
+delta-sat with delta = 0.001


### PR DESCRIPTION
This fixes a number of problems with the current code for parsing hex floats, chiefly:

- Only allowing one _decimal_ digit before the radix point.
- Mandatory point and exponent.

Note that the token is passed to `atof`, which parses in the same way as `strtod`.

The new rule allows tokens such as `0xA`, which are not strictly allowed by `strtod`, which is specified to require either a radix point or an exponent. However, this form seems to be accepted by the Linux `strtod`, and handling it separately would greatly complicate parsing. In future, this form should perhaps be read as an INT instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dreal/dreal4/44)
<!-- Reviewable:end -->
