### PR TITLE
feat(smt2): Allow string values in (set-info)

### DIFF
--- a/dreal/smt2/parser.yy
+++ b/dreal/smt2/parser.yy
@@ -222,6 +222,13 @@ command_set_info:
                     delete $3;
                     delete $4;
                 }
+        |       '(' TK_SET_INFO KEYWORD STRING ')' {
+                    driver
+                        .context_
+                        .SetInfo(*$3, *$4);
+                    delete $3;
+                    delete $4;
+                }
         |       '(' TK_SET_INFO KEYWORD DOUBLE ')' {
                     driver
                         .context_


### PR DESCRIPTION
Quite a few benchmarks use string values here. According to the spec, it can be any S-expression other than a keyword, although most predefined attributes use a more restricted category of values.

As `STRING` and `SYMBOL` are both of token type `<stringVal>`, the code is exactly the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dreal/dreal4/56)
<!-- Reviewable:end -->
