### PR TITLE
feat(smt2): Support (declare-const) and refactor

### DIFF
--- a/dreal/smt2/BUILD
+++ b/dreal/smt2/BUILD
@@ -39,6 +39,7 @@ dreal_cc_library(
         "sort.h",
     ],
     deps = [
+        "//dreal/symbolic",
         "//dreal/util:exception",
     ],
 )

--- a/dreal/smt2/driver.cc
+++ b/dreal/smt2/driver.cc
@@ -71,15 +71,17 @@ void Smt2Driver::RegisterVariable(const Variable& v) {
   scope_.insert(v.get_name(), v);
 }
 
-void Smt2Driver::DeclareVariable(const Variable& v) {
+void Smt2Driver::DeclareVariable(const std::string& name, Sort sort) {
+  Variable v{ ParseVariableSort(name, sort) };
   RegisterVariable(v);
   context_.DeclareVariable(v);
 }
 
-void Smt2Driver::DeclareVariable(const Variable& v, const Expression& lb,
-                                 const Expression& ub) {
+void Smt2Driver::DeclareVariable(const std::string& name, Sort sort,
+                                 const Term& lb, const Term& ub) {
+  Variable v{ ParseVariableSort(name, sort) };
   RegisterVariable(v);
-  context_.DeclareVariable(v, lb, ub);
+  context_.DeclareVariable(v, lb.expression(), ub.expression());
 }
 
 const Variable& Smt2Driver::lookup_variable(const string& name) {
@@ -91,18 +93,7 @@ const Variable& Smt2Driver::lookup_variable(const string& name) {
 }
 
 Variable Smt2Driver::ParseVariableSort(const std::string& name, const Sort s) {
-  switch (s) {
-    case Sort::Bool:
-      return Variable{name, Variable::Type::BOOLEAN};
-      break;
-    case Sort::Int:
-      return Variable{name, Variable::Type::INTEGER};
-      break;
-    case Sort::Real:
-      return Variable{name, Variable::Type::CONTINUOUS};
-      break;
-  }
-  DREAL_UNREACHABLE();
+  return Variable{name, SortToType(s)};
 }
 
 }  // namespace dreal

--- a/dreal/smt2/driver.h
+++ b/dreal/smt2/driver.h
@@ -64,12 +64,13 @@ class Smt2Driver {
   /// declare the variable in the context.
   void RegisterVariable(const Variable& v);
 
-  /// Declare a variable @p v.
-  void DeclareVariable(const Variable& v);
+  /// Declare a variable with name @p name and sort @p sort.
+  void DeclareVariable(const std::string& name, Sort sort);
 
-  /// Declare a variable @p v which is bounded by an interval `[lb, ub]`.
-  void DeclareVariable(const Variable& v, const Expression& lb,
-                       const Expression& ub);
+  /// Declare a variable with name @p name and sort @p sort which is bounded by
+  /// an interval `[lb, ub]`.
+  void DeclareVariable(const std::string& name, Sort sort,
+                       const Term& lb, const Term& ub);
 
   /// Returns a variable associated with a name @p name.
   ///

--- a/dreal/smt2/parser.yy
+++ b/dreal/smt2/parser.yy
@@ -154,47 +154,27 @@ command_check_sat:
                 ;
 command_declare_fun:
                 '(' TK_DECLARE_FUN SYMBOL '(' ')' sort ')' {
-                    switch ($6) {
-                      case Sort::Bool:
-                        driver
-                            .DeclareVariable(Variable{*$3, Variable::Type::BOOLEAN});
-                        break;
-                      case Sort::Int:
-                        driver
-                            .DeclareVariable(Variable{*$3, Variable::Type::INTEGER});
-                        break;
-                      case Sort::Real:
-                        driver
-                            .DeclareVariable(Variable{*$3, Variable::Type::CONTINUOUS});
-                        break;
-                    }
+                    driver.DeclareVariable(*$3, $6);
                     delete $3;
                 }
         |
                 '(' TK_DECLARE_FUN SYMBOL '(' ')' sort '[' term ',' term ']' ')' {
-                    switch ($6) {
-                      case Sort::Bool:
-                        driver
-                            .DeclareVariable(Variable{*$3, Variable::Type::BOOLEAN},
-                                             $8->expression(),
-                                             $10->expression());
-                        break;
-                      case Sort::Int:
-                        driver
-                            .DeclareVariable(Variable{*$3, Variable::Type::INTEGER},
-                                             $8->expression(),
-                                             $10->expression());
-                        break;
-                      case Sort::Real:
-                        driver
-                            .DeclareVariable(Variable{*$3, Variable::Type::CONTINUOUS},
-                                             $8->expression(),
-                                             $10->expression());
-                        break;
-                    }
+                    driver.DeclareVariable(*$3, $6, *$8, *$10);
                     delete $3;
                     delete $8;
                     delete $10;
+                }
+        |
+                '(' TK_DECLARE_CONST SYMBOL sort ')' {
+                    driver.DeclareVariable(*$3, $4);
+                    delete $3;
+                }
+        |
+                '(' TK_DECLARE_CONST SYMBOL sort '[' term ',' term ']' ')' {
+                    driver.DeclareVariable(*$3, $4, *$6, *$8);
+                    delete $3;
+                    delete $6;
+                    delete $8;
                 }
                 ;
 

--- a/dreal/smt2/sort.cc
+++ b/dreal/smt2/sort.cc
@@ -31,4 +31,17 @@ ostream& operator<<(ostream& os, const Sort& sort) {
   }
   DREAL_UNREACHABLE();
 }
+
+Variable::Type SortToType(Sort sort) {
+  switch (sort) {
+    case Sort::Bool:
+      return Variable::Type::BOOLEAN;
+    case Sort::Int:
+      return Variable::Type::INTEGER;
+    case Sort::Real:
+      return Variable::Type::CONTINUOUS;
+  }
+  DREAL_UNREACHABLE();
+}
+
 }  // namespace dreal

--- a/dreal/smt2/sort.h
+++ b/dreal/smt2/sort.h
@@ -3,6 +3,8 @@
 #include <ostream>
 #include <string>
 
+#include "dreal/symbolic/symbolic.h"
+
 namespace dreal {
 
 // TODO(soonho): Extend this.
@@ -15,5 +17,7 @@ enum class Sort {
 Sort ParseSort(const std::string& s);
 
 std::ostream& operator<<(std::ostream& os, const Sort& sort);
+
+Variable::Type SortToType(Sort sort);
 
 }  // namespace dreal


### PR DESCRIPTION
`(declare-const f sigma)` abbreviates the command `(declare-fun f () sigma)`.
[The SMT-LIB Standard](http://smtlib.cs.uiowa.edu/language.shtml), version 2.6, p.60

New function `SortToType` converts from `Sort` to `Variable::Type`.

`Smt2Driver::DeclareVariable` now takes `std::string&`, `Sort`, and `Term&` directly, partly consolidating the multiple occurrences in the parser.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dreal/dreal4/58)
<!-- Reviewable:end -->
