### PR TITLE
feat(smt2): Support logic types QF_LRA and QF_RDL

### DIFF
--- a/dreal/smt2/logic.cc
+++ b/dreal/smt2/logic.cc
@@ -14,6 +14,12 @@ Logic parse_logic(const string& s) {
   if (s == "QF_NRA_ODE") {
     return Logic::QF_NRA_ODE;
   }
+  if (s == "QF_LRA") {
+    return Logic::QF_LRA;
+  }
+  if (s == "QF_RDL") {
+    return Logic::QF_RDL;
+  }
   throw DREAL_RUNTIME_ERROR("set-logic({}) is not supported.", s);
 }
 
@@ -23,6 +29,10 @@ ostream& operator<<(ostream& os, const Logic& logic) {
       return os << "QF_NRA";
     case Logic::QF_NRA_ODE:
       return os << "QF_NRA_ODE";
+    case Logic::QF_LRA:
+      return os << "QF_LRA";
+    case Logic::QF_RDL:
+      return os << "QF_RDL";
   }
   DREAL_UNREACHABLE();
 }

--- a/dreal/smt2/logic.h
+++ b/dreal/smt2/logic.h
@@ -8,6 +8,8 @@ namespace dreal {
 enum class Logic {
   QF_NRA,
   QF_NRA_ODE,
+  QF_LRA,
+  QF_RDL,
 };
 
 Logic parse_logic(const std::string& s);


### PR DESCRIPTION
I have a lot of benchmarks that specify logic QF_LRA rather than QF_NRA. As QF_LRA is a subset of QF_NRA, and the Logic setting isn't actually checked anywhere else within dReal4, it's just a matter of adding it to logic.{cc,h}.

Looking at the chart on http://smtlib.cs.uiowa.edu/logics.shtml, I noticed that there is also QF_RDL (real difference logic), which is obviously a subset of QF_LRA. So it makes sense to add that as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dreal/dreal4/63)
<!-- Reviewable:end -->
