### PR TITLE
feat: Parse from stdin; add --format option

### DIFF
--- a/dreal/dr/driver.cc
+++ b/dreal/dr/driver.cc
@@ -39,7 +39,8 @@ bool DrDriver::parse_stream(istream& in, const string& sname) {
 }
 
 bool DrDriver::parse_file(const string& filename) {
-  if (filename == "-") {
+  if (filename == "") {
+    // Option --in passed to dreal.
     return parse_stream(cin, "(stdin)");
   }
   ifstream in(filename.c_str());

--- a/dreal/dr/driver.cc
+++ b/dreal/dr/driver.cc
@@ -15,6 +15,7 @@ namespace dreal {
 
 using std::cerr;
 using std::cout;
+using std::cin;
 using std::endl;
 using std::experimental::optional;
 using std::ifstream;
@@ -38,6 +39,9 @@ bool DrDriver::parse_stream(istream& in, const string& sname) {
 }
 
 bool DrDriver::parse_file(const string& filename) {
+  if (filename == "-") {
+    return parse_stream(cin, "(stdin)");
+  }
   ifstream in(filename.c_str());
   if (!in.good()) {
     return false;

--- a/dreal/smt2/driver.cc
+++ b/dreal/smt2/driver.cc
@@ -39,7 +39,8 @@ bool Smt2Driver::parse_stream(istream& in, const string& sname) {
 }
 
 bool Smt2Driver::parse_file(const string& filename) {
-  if (filename == "-") {
+  if (filename == "") {
+    // Option --in passed to dreal.
     return parse_stream(cin, "(stdin)");
   }
   ifstream in(filename.c_str());

--- a/dreal/smt2/driver.cc
+++ b/dreal/smt2/driver.cc
@@ -14,6 +14,7 @@ namespace dreal {
 
 using std::cerr;
 using std::cout;
+using std::cin;
 using std::endl;
 using std::experimental::optional;
 using std::ifstream;
@@ -38,6 +39,9 @@ bool Smt2Driver::parse_stream(istream& in, const string& sname) {
 }
 
 bool Smt2Driver::parse_file(const string& filename) {
+  if (filename == "-") {
+    return parse_stream(cin, "(stdin)");
+  }
   ifstream in(filename.c_str());
   if (!in.good()) {
     return false;


### PR DESCRIPTION
I have some large smt2 files that are `gzip`ped, and I want to feed them into `dreal` without having to store the decompressed files in the filesystem. I considered using `boost::iostreams::gzip`, but `flex`'s C++ classes insist on receiving a `std::istream*`, which that does not provide. So I think the best way is just to pipe `zcat` into the `dreal` process.

This means that we need a way for `dreal` to receive input on `stdin`, and so we can't rely on the file extension any more, so there has to be an option to specify the format.

My solution:

Giving `dreal` a filename of `-` will make it read from `stdin` (actually `cin`). The filename is reported as `(stdin)` (with the brackets).

| Option                | Behaviour |
| ------------------- | ------------- |
| `--format auto`   | the default behaviour (use file extension; use smt2 if reading from `stdin`) |
| `--format smt2`  | assumes smt2; does not check extension |
| `--format dr`       | assumes dr; does not check extension |

Built with `gcc-6`, `gcc-5` and `clang-4.0`.
`bazel test //...`: Executed 202 out of 296 tests: 296 tests pass.
`bazel test --config kcov //...`: Executed 202 out of 202 tests: 202 tests pass.
`bazel test //... --config=asan`: Executed 202 out of 293 tests: 293 tests pass.
Rebase: upstream `master` checked at 2018-04-09 10:27:55 UTC

I made the option case-sensitive because (a) handling case-insensitive values would have involved slightly more code, and (b) I noticed that the existing --verbose option, which is case-insensitive, doesn't handle non-lowercase values correctly. For instance, if you give it --verbose TRACE, this doesn't do the same as --verbose trace. So only handling lowercase values is consistent with existing behaviour, in a sense.

The change is largely self-documenting, so I didn't write any extra comments or documentation. Also, it's not so easy to test, so I didn't write any automated tests (but I did test a variety of different cases).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dreal/dreal4/79)
<!-- Reviewable:end -->
