### PR TITLE
Added python-apt as to list of installed packaged in install_prereqs.sh

### DIFF
--- a/setup/ubuntu/14.04/install_prereqs.sh
+++ b/setup/ubuntu/14.04/install_prereqs.sh
@@ -24,6 +24,7 @@ libnlopt-dev
 libpython2.7-dev
 openjdk-8-jdk
 pkg-config
+python-apt
 python-dev
 zlib1g-dev
 EOF

--- a/setup/ubuntu/16.04/install_prereqs.sh
+++ b/setup/ubuntu/16.04/install_prereqs.sh
@@ -19,6 +19,7 @@ libnlopt-dev
 libpython2.7-dev
 openjdk-8-jdk
 pkg-config
+python-apt
 python-dev
 zlib1g-dev
 EOF

--- a/setup/ubuntu/18.04/install_prereqs.sh
+++ b/setup/ubuntu/18.04/install_prereqs.sh
@@ -20,6 +20,7 @@ libnlopt-dev
 libpython2.7-dev
 openjdk-8-jdk
 pkg-config
+python-apt
 python-dev
 zlib1g-dev
 EOF


### PR DESCRIPTION
python-dev requires python-apt to be installed, causes installation to fail if not installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dreal/dreal4/89)
<!-- Reviewable:end -->
