### PR TITLE
Fix fmt-related build errors when in --std=c++20 mode

### DIFF
--- a/dreal/smt2/sort.cc
+++ b/dreal/smt2/sort.cc
@@ -35,7 +35,7 @@ Sort ParseSort(const string& s) {
   if (s == "Binary") {
     return Sort::Binary;
   }
-  throw DREAL_RUNTIME_ERROR("{} is not one of {Real, Int, Bool}.", s);
+  throw DREAL_RUNTIME_ERROR("{} is not one of {{Real, Int, Bool}}.", s);
 }
 
 ostream& operator<<(ostream& os, const Sort& sort) {

--- a/dreal/util/ibex_converter.cc
+++ b/dreal/util/ibex_converter.cc
@@ -138,7 +138,7 @@ const ExprNode* IbexConverter::VisitVariable(const Expression& e) {
       oss << v << " ";
     }
     oss << ".";
-    throw DREAL_RUNTIME_ERROR(oss.str());
+    throw DREAL_RUNTIME_ERROR("{}", oss.str());
   }
   return it->second;
 }


### PR DESCRIPTION
When `fmt >= 8` is compiled in `c++ >= 20` mode, it does `constexpr`-based pattern validation, leading to compile-time errors for invalid format strings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dreal/dreal4/283)
<!-- Reviewable:end -->
